### PR TITLE
:weight_lifting: :tada: Add support for `chef_dynamics` & define for UR5e

### DIFF
--- a/ur_description/config/ur5e/physical_parameters.yaml
+++ b/ur_description/config/ur5e/physical_parameters.yaml
@@ -123,43 +123,45 @@ inertia_parameters:
       iyz: 0
       izz: 0.0001321171875
 
-# Motor dynamics
-# Frictions derived from here: https://docs.google.com/spreadsheets/d/1l5ALgBcOG7bib8kCmkV5400Q8j62zNZdqExMIk1tpHg/edit?usp=sharing
-# Inertias derived from table IV in: https://www.cambridge.org/core/journals/robotica/article/electromechanical-modeling-and-identification-of-the-ur5-eseries-robot/1AE5BAE866D9046F79C4B159BEA2B45F?utm_campaign=shareaholic&utm_medium=copy_link&utm_source=bookmark
-motor_dynamics:
+# Joint dynamics -- loaded into the `chef_dynamics` element in URDF `joint` elements.
+# Frictions are in the joint/"output" reference frame, i.e. after the gear box, and are derived here:
+# https://docs.google.com/spreadsheets/d/1l5ALgBcOG7bib8kCmkV5400Q8j62zNZdqExMIk1tpHg/edit?usp=sharing
+# Inertias are in the motor reference frame, i.e. before the gear box, and are derived from table IV in:
+# https://www.cambridge.org/core/journals/robotica/article/electromechanical-modeling-and-identification-of-the-ur5-eseries-robot/1AE5BAE866D9046F79C4B159BEA2B45F?utm_campaign=shareaholic&utm_medium=copy_link&utm_source=bookmark
+joint_dynamics:
   shoulder_pan_joint:
-    static_friction: 0.05113
-    viscous_friction: 0.038396875
+    coulomb_friction: 0.05113  # Nm
+    viscous_damping: 0.038396875  # Nm*s/rad
     gear_ratio: 101.0
-    rotor_inertia: 6.6119e-05
-    reducer_inertia: 10.7e-05
+    rotor_inertia: 6.6119e-05  # kg*m^2
+    reducer_inertia: 10.7e-05  # kg*m^2
   shoulder_lift_joint:
-    static_friction: 0.094925
-    viscous_friction: 0.0493984375
+    coulomb_friction: 0.094925
+    viscous_damping: 0.0493984375
     gear_ratio: 101.0
     rotor_inertia: 4.6147e-05
     reducer_inertia: 10.7e-05
   elbow_joint:
-    static_friction: 0.07349
-    viscous_friction: 0.042971875
+    coulomb_friction: 0.07349
+    viscous_damping: 0.042971875
     gear_ratio: 101.0
     rotor_inertia: 7.9773e-05
     reducer_inertia: 10.7e-05
   wrist_1_joint:
-    static_friction: 0.01628
-    viscous_friction: 0.00835
+    coulomb_friction: 0.01628
+    viscous_damping: 0.00835
     gear_ratio: 101.0
     rotor_inertia: 1.2249e-05
     reducer_inertia: 0.91e-05
   wrist_2_joint:
-    static_friction: 0.016135
-    viscous_friction: 0.0076140625
+    coulomb_friction: 0.016135
+    viscous_damping: 0.0076140625
     gear_ratio: 101.0
     rotor_inertia: 1.1868e-05
     reducer_inertia: 0.91e-05
   wrist_3_joint:
-    static_friction: 0.020835
-    viscous_friction: 0.0080203125
+    coulomb_friction: 0.020835
+    viscous_damping: 0.0080203125
     gear_ratio: 101.0
     rotor_inertia: 1.1981e-05
     reducer_inertia: 0.91e-05

--- a/ur_description/config/ur5e/physical_parameters.yaml
+++ b/ur_description/config/ur5e/physical_parameters.yaml
@@ -122,3 +122,44 @@ inertia_parameters:
       iyy: 9.890414008333333e-05
       iyz: 0
       izz: 0.0001321171875
+
+# Motor dynamics
+# Frictions derived from here: https://docs.google.com/spreadsheets/d/1l5ALgBcOG7bib8kCmkV5400Q8j62zNZdqExMIk1tpHg/edit?usp=sharing
+# Inertias derived from table IV in: https://www.cambridge.org/core/journals/robotica/article/electromechanical-modeling-and-identification-of-the-ur5-eseries-robot/1AE5BAE866D9046F79C4B159BEA2B45F?utm_campaign=shareaholic&utm_medium=copy_link&utm_source=bookmark
+motor_dynamics:
+  shoulder_pan_joint:
+    static_friction: 0.05113
+    viscous_friction: 0.038396875
+    gear_ratio: 101.0
+    rotor_inertia: 6.6119e-05
+    reducer_inertia: 10.7e-05
+  shoulder_lift_joint:
+    static_friction: 0.094925
+    viscous_friction: 0.0493984375
+    gear_ratio: 101.0
+    rotor_inertia: 4.6147e-05
+    reducer_inertia: 10.7e-05
+  elbow_joint:
+    static_friction: 0.07349
+    viscous_friction: 0.042971875
+    gear_ratio: 101.0
+    rotor_inertia: 7.9773e-05
+    reducer_inertia: 10.7e-05
+  wrist_1_joint:
+    static_friction: 0.01628
+    viscous_friction: 0.00835
+    gear_ratio: 101.0
+    rotor_inertia: 1.2249e-05
+    reducer_inertia: 0.91e-05
+  wrist_2_joint:
+    static_friction: 0.016135
+    viscous_friction: 0.0076140625
+    gear_ratio: 101.0
+    rotor_inertia: 1.1868e-05
+    reducer_inertia: 0.91e-05
+  wrist_3_joint:
+    static_friction: 0.020835
+    viscous_friction: 0.0080203125
+    gear_ratio: 101.0
+    rotor_inertia: 1.1981e-05
+    reducer_inertia: 0.91e-05

--- a/ur_description/urdf/inc/ur_common.xacro
+++ b/ur_description/urdf/inc/ur_common.xacro
@@ -38,7 +38,7 @@
     <xacro:property name="sec_limits" value="${config_joint_limit_parameters['joint_limits']}"/>
     <xacro:property name="sec_offsets" value="${config_physical_parameters['offsets']}"/>
     <xacro:property name="sec_inertia_parameters" value="${config_physical_parameters['inertia_parameters']}" />
-    <xacro:property name="sec_motor_dynamics" value="${config_physical_parameters['motor_dynamics']}" />
+    <xacro:property name="sec_joint_dynamics" value="${config_physical_parameters['joint_dynamics']}" />
     <xacro:property name="sec_mesh_files" value="${config_visual_parameters['mesh_files']}" />
     <xacro:property name="sec_kinematics" value="${config_kinematics_parameters['kinematics']}" />
 
@@ -68,42 +68,42 @@
     <xacro:property name="wrist_3_velocity_limit" value="${sec_limits['wrist_3_joint']['max_velocity']}" scope="parent"/>
     <xacro:property name="wrist_3_effort_limit" value="${sec_limits['wrist_3_joint']['max_effort']}" scope="parent"/>
 
-    <!-- MOTOR DYNAMICS PARAMETERS -->
-    <xacro:property name="shoulder_pan_joint_static_friction" value="${sec_motor_dynamics['shoulder_pan_joint']['static_friction']}" scope="parent"/>
-    <xacro:property name="shoulder_pan_joint_viscous_friction" value="${sec_motor_dynamics['shoulder_pan_joint']['viscous_friction']}" scope="parent"/>
-    <xacro:property name="shoulder_pan_joint_gear_ratio" value="${sec_motor_dynamics['shoulder_pan_joint']['gear_ratio']}" scope="parent"/>
-    <xacro:property name="shoulder_pan_joint_rotor_inertia" value="${sec_motor_dynamics['shoulder_pan_joint']['rotor_inertia']}" scope="parent"/>
-    <xacro:property name="shoulder_pan_joint_reducer_inertia" value="${sec_motor_dynamics['shoulder_pan_joint']['reducer_inertia']}" scope="parent"/>
+    <!-- JOINT DYNAMICS PARAMETERS -->
+    <xacro:property name="shoulder_pan_joint_coulomb_friction" value="${sec_joint_dynamics['shoulder_pan_joint']['coulomb_friction']}" scope="parent"/>
+    <xacro:property name="shoulder_pan_joint_viscous_damping" value="${sec_joint_dynamics['shoulder_pan_joint']['viscous_damping']}" scope="parent"/>
+    <xacro:property name="shoulder_pan_joint_gear_ratio" value="${sec_joint_dynamics['shoulder_pan_joint']['gear_ratio']}" scope="parent"/>
+    <xacro:property name="shoulder_pan_joint_rotor_inertia" value="${sec_joint_dynamics['shoulder_pan_joint']['rotor_inertia']}" scope="parent"/>
+    <xacro:property name="shoulder_pan_joint_reducer_inertia" value="${sec_joint_dynamics['shoulder_pan_joint']['reducer_inertia']}" scope="parent"/>
 
-    <xacro:property name="shoulder_lift_joint_static_friction" value="${sec_motor_dynamics['shoulder_lift_joint']['static_friction']}" scope="parent"/>
-    <xacro:property name="shoulder_lift_joint_viscous_friction" value="${sec_motor_dynamics['shoulder_lift_joint']['viscous_friction']}" scope="parent"/>
-    <xacro:property name="shoulder_lift_joint_gear_ratio" value="${sec_motor_dynamics['shoulder_lift_joint']['gear_ratio']}" scope="parent"/>
-    <xacro:property name="shoulder_lift_joint_rotor_inertia" value="${sec_motor_dynamics['shoulder_lift_joint']['rotor_inertia']}" scope="parent"/>
-    <xacro:property name="shoulder_lift_joint_reducer_inertia" value="${sec_motor_dynamics['shoulder_lift_joint']['reducer_inertia']}" scope="parent"/>
+    <xacro:property name="shoulder_lift_joint_coulomb_friction" value="${sec_joint_dynamics['shoulder_lift_joint']['coulomb_friction']}" scope="parent"/>
+    <xacro:property name="shoulder_lift_joint_viscous_damping" value="${sec_joint_dynamics['shoulder_lift_joint']['viscous_damping']}" scope="parent"/>
+    <xacro:property name="shoulder_lift_joint_gear_ratio" value="${sec_joint_dynamics['shoulder_lift_joint']['gear_ratio']}" scope="parent"/>
+    <xacro:property name="shoulder_lift_joint_rotor_inertia" value="${sec_joint_dynamics['shoulder_lift_joint']['rotor_inertia']}" scope="parent"/>
+    <xacro:property name="shoulder_lift_joint_reducer_inertia" value="${sec_joint_dynamics['shoulder_lift_joint']['reducer_inertia']}" scope="parent"/>
 
-    <xacro:property name="elbow_joint_static_friction" value="${sec_motor_dynamics['elbow_joint']['static_friction']}" scope="parent"/>
-    <xacro:property name="elbow_joint_viscous_friction" value="${sec_motor_dynamics['elbow_joint']['viscous_friction']}" scope="parent"/>
-    <xacro:property name="elbow_joint_gear_ratio" value="${sec_motor_dynamics['elbow_joint']['gear_ratio']}" scope="parent"/>
-    <xacro:property name="elbow_joint_rotor_inertia" value="${sec_motor_dynamics['elbow_joint']['rotor_inertia']}" scope="parent"/>
-    <xacro:property name="elbow_joint_reducer_inertia" value="${sec_motor_dynamics['elbow_joint']['reducer_inertia']}" scope="parent"/>
+    <xacro:property name="elbow_joint_coulomb_friction" value="${sec_joint_dynamics['elbow_joint']['coulomb_friction']}" scope="parent"/>
+    <xacro:property name="elbow_joint_viscous_damping" value="${sec_joint_dynamics['elbow_joint']['viscous_damping']}" scope="parent"/>
+    <xacro:property name="elbow_joint_gear_ratio" value="${sec_joint_dynamics['elbow_joint']['gear_ratio']}" scope="parent"/>
+    <xacro:property name="elbow_joint_rotor_inertia" value="${sec_joint_dynamics['elbow_joint']['rotor_inertia']}" scope="parent"/>
+    <xacro:property name="elbow_joint_reducer_inertia" value="${sec_joint_dynamics['elbow_joint']['reducer_inertia']}" scope="parent"/>
 
-    <xacro:property name="wrist_1_joint_static_friction" value="${sec_motor_dynamics['wrist_1_joint']['static_friction']}" scope="parent"/>
-    <xacro:property name="wrist_1_joint_viscous_friction" value="${sec_motor_dynamics['wrist_1_joint']['viscous_friction']}" scope="parent"/>
-    <xacro:property name="wrist_1_joint_gear_ratio" value="${sec_motor_dynamics['wrist_1_joint']['gear_ratio']}" scope="parent"/>
-    <xacro:property name="wrist_1_joint_rotor_inertia" value="${sec_motor_dynamics['wrist_1_joint']['rotor_inertia']}" scope="parent"/>
-    <xacro:property name="wrist_1_joint_reducer_inertia" value="${sec_motor_dynamics['wrist_1_joint']['reducer_inertia']}" scope="parent"/>
+    <xacro:property name="wrist_1_joint_coulomb_friction" value="${sec_joint_dynamics['wrist_1_joint']['coulomb_friction']}" scope="parent"/>
+    <xacro:property name="wrist_1_joint_viscous_damping" value="${sec_joint_dynamics['wrist_1_joint']['viscous_damping']}" scope="parent"/>
+    <xacro:property name="wrist_1_joint_gear_ratio" value="${sec_joint_dynamics['wrist_1_joint']['gear_ratio']}" scope="parent"/>
+    <xacro:property name="wrist_1_joint_rotor_inertia" value="${sec_joint_dynamics['wrist_1_joint']['rotor_inertia']}" scope="parent"/>
+    <xacro:property name="wrist_1_joint_reducer_inertia" value="${sec_joint_dynamics['wrist_1_joint']['reducer_inertia']}" scope="parent"/>
 
-    <xacro:property name="wrist_2_joint_static_friction" value="${sec_motor_dynamics['wrist_2_joint']['static_friction']}" scope="parent"/>
-    <xacro:property name="wrist_2_joint_viscous_friction" value="${sec_motor_dynamics['wrist_2_joint']['viscous_friction']}" scope="parent"/>
-    <xacro:property name="wrist_2_joint_gear_ratio" value="${sec_motor_dynamics['wrist_2_joint']['gear_ratio']}" scope="parent"/>
-    <xacro:property name="wrist_2_joint_rotor_inertia" value="${sec_motor_dynamics['wrist_2_joint']['rotor_inertia']}" scope="parent"/>
-    <xacro:property name="wrist_2_joint_reducer_inertia" value="${sec_motor_dynamics['wrist_2_joint']['reducer_inertia']}" scope="parent"/>
+    <xacro:property name="wrist_2_joint_coulomb_friction" value="${sec_joint_dynamics['wrist_2_joint']['coulomb_friction']}" scope="parent"/>
+    <xacro:property name="wrist_2_joint_viscous_damping" value="${sec_joint_dynamics['wrist_2_joint']['viscous_damping']}" scope="parent"/>
+    <xacro:property name="wrist_2_joint_gear_ratio" value="${sec_joint_dynamics['wrist_2_joint']['gear_ratio']}" scope="parent"/>
+    <xacro:property name="wrist_2_joint_rotor_inertia" value="${sec_joint_dynamics['wrist_2_joint']['rotor_inertia']}" scope="parent"/>
+    <xacro:property name="wrist_2_joint_reducer_inertia" value="${sec_joint_dynamics['wrist_2_joint']['reducer_inertia']}" scope="parent"/>
 
-    <xacro:property name="wrist_3_joint_static_friction" value="${sec_motor_dynamics['wrist_3_joint']['static_friction']}" scope="parent"/>
-    <xacro:property name="wrist_3_joint_viscous_friction" value="${sec_motor_dynamics['wrist_3_joint']['viscous_friction']}" scope="parent"/>
-    <xacro:property name="wrist_3_joint_gear_ratio" value="${sec_motor_dynamics['wrist_3_joint']['gear_ratio']}" scope="parent"/>
-    <xacro:property name="wrist_3_joint_rotor_inertia" value="${sec_motor_dynamics['wrist_3_joint']['rotor_inertia']}" scope="parent"/>
-    <xacro:property name="wrist_3_joint_reducer_inertia" value="${sec_motor_dynamics['wrist_3_joint']['reducer_inertia']}" scope="parent"/>
+    <xacro:property name="wrist_3_joint_coulomb_friction" value="${sec_joint_dynamics['wrist_3_joint']['coulomb_friction']}" scope="parent"/>
+    <xacro:property name="wrist_3_joint_viscous_damping" value="${sec_joint_dynamics['wrist_3_joint']['viscous_damping']}" scope="parent"/>
+    <xacro:property name="wrist_3_joint_gear_ratio" value="${sec_joint_dynamics['wrist_3_joint']['gear_ratio']}" scope="parent"/>
+    <xacro:property name="wrist_3_joint_rotor_inertia" value="${sec_joint_dynamics['wrist_3_joint']['rotor_inertia']}" scope="parent"/>
+    <xacro:property name="wrist_3_joint_reducer_inertia" value="${sec_joint_dynamics['wrist_3_joint']['reducer_inertia']}" scope="parent"/>
 
     <!-- kinematics -->
     <xacro:property name="shoulder_x" value="${sec_kinematics['shoulder']['x']}" scope="parent"/>

--- a/ur_description/urdf/inc/ur_common.xacro
+++ b/ur_description/urdf/inc/ur_common.xacro
@@ -38,6 +38,7 @@
     <xacro:property name="sec_limits" value="${config_joint_limit_parameters['joint_limits']}"/>
     <xacro:property name="sec_offsets" value="${config_physical_parameters['offsets']}"/>
     <xacro:property name="sec_inertia_parameters" value="${config_physical_parameters['inertia_parameters']}" />
+    <xacro:property name="sec_motor_dynamics" value="${config_physical_parameters['motor_dynamics']}" />
     <xacro:property name="sec_mesh_files" value="${config_visual_parameters['mesh_files']}" />
     <xacro:property name="sec_kinematics" value="${config_kinematics_parameters['kinematics']}" />
 
@@ -66,6 +67,43 @@
     <xacro:property name="wrist_3_upper_limit" value="${sec_limits['wrist_3_joint']['max_position']}" scope="parent"/>
     <xacro:property name="wrist_3_velocity_limit" value="${sec_limits['wrist_3_joint']['max_velocity']}" scope="parent"/>
     <xacro:property name="wrist_3_effort_limit" value="${sec_limits['wrist_3_joint']['max_effort']}" scope="parent"/>
+
+    <!-- MOTOR DYNAMICS PARAMETERS -->
+    <xacro:property name="shoulder_pan_joint_static_friction" value="${sec_motor_dynamics['shoulder_pan_joint']['static_friction']}" scope="parent"/>
+    <xacro:property name="shoulder_pan_joint_viscous_friction" value="${sec_motor_dynamics['shoulder_pan_joint']['viscous_friction']}" scope="parent"/>
+    <xacro:property name="shoulder_pan_joint_gear_ratio" value="${sec_motor_dynamics['shoulder_pan_joint']['gear_ratio']}" scope="parent"/>
+    <xacro:property name="shoulder_pan_joint_rotor_inertia" value="${sec_motor_dynamics['shoulder_pan_joint']['rotor_inertia']}" scope="parent"/>
+    <xacro:property name="shoulder_pan_joint_reducer_inertia" value="${sec_motor_dynamics['shoulder_pan_joint']['reducer_inertia']}" scope="parent"/>
+
+    <xacro:property name="shoulder_lift_joint_static_friction" value="${sec_motor_dynamics['shoulder_lift_joint']['static_friction']}" scope="parent"/>
+    <xacro:property name="shoulder_lift_joint_viscous_friction" value="${sec_motor_dynamics['shoulder_lift_joint']['viscous_friction']}" scope="parent"/>
+    <xacro:property name="shoulder_lift_joint_gear_ratio" value="${sec_motor_dynamics['shoulder_lift_joint']['gear_ratio']}" scope="parent"/>
+    <xacro:property name="shoulder_lift_joint_rotor_inertia" value="${sec_motor_dynamics['shoulder_lift_joint']['rotor_inertia']}" scope="parent"/>
+    <xacro:property name="shoulder_lift_joint_reducer_inertia" value="${sec_motor_dynamics['shoulder_lift_joint']['reducer_inertia']}" scope="parent"/>
+
+    <xacro:property name="elbow_joint_static_friction" value="${sec_motor_dynamics['elbow_joint']['static_friction']}" scope="parent"/>
+    <xacro:property name="elbow_joint_viscous_friction" value="${sec_motor_dynamics['elbow_joint']['viscous_friction']}" scope="parent"/>
+    <xacro:property name="elbow_joint_gear_ratio" value="${sec_motor_dynamics['elbow_joint']['gear_ratio']}" scope="parent"/>
+    <xacro:property name="elbow_joint_rotor_inertia" value="${sec_motor_dynamics['elbow_joint']['rotor_inertia']}" scope="parent"/>
+    <xacro:property name="elbow_joint_reducer_inertia" value="${sec_motor_dynamics['elbow_joint']['reducer_inertia']}" scope="parent"/>
+
+    <xacro:property name="wrist_1_joint_static_friction" value="${sec_motor_dynamics['wrist_1_joint']['static_friction']}" scope="parent"/>
+    <xacro:property name="wrist_1_joint_viscous_friction" value="${sec_motor_dynamics['wrist_1_joint']['viscous_friction']}" scope="parent"/>
+    <xacro:property name="wrist_1_joint_gear_ratio" value="${sec_motor_dynamics['wrist_1_joint']['gear_ratio']}" scope="parent"/>
+    <xacro:property name="wrist_1_joint_rotor_inertia" value="${sec_motor_dynamics['wrist_1_joint']['rotor_inertia']}" scope="parent"/>
+    <xacro:property name="wrist_1_joint_reducer_inertia" value="${sec_motor_dynamics['wrist_1_joint']['reducer_inertia']}" scope="parent"/>
+
+    <xacro:property name="wrist_2_joint_static_friction" value="${sec_motor_dynamics['wrist_2_joint']['static_friction']}" scope="parent"/>
+    <xacro:property name="wrist_2_joint_viscous_friction" value="${sec_motor_dynamics['wrist_2_joint']['viscous_friction']}" scope="parent"/>
+    <xacro:property name="wrist_2_joint_gear_ratio" value="${sec_motor_dynamics['wrist_2_joint']['gear_ratio']}" scope="parent"/>
+    <xacro:property name="wrist_2_joint_rotor_inertia" value="${sec_motor_dynamics['wrist_2_joint']['rotor_inertia']}" scope="parent"/>
+    <xacro:property name="wrist_2_joint_reducer_inertia" value="${sec_motor_dynamics['wrist_2_joint']['reducer_inertia']}" scope="parent"/>
+
+    <xacro:property name="wrist_3_joint_static_friction" value="${sec_motor_dynamics['wrist_3_joint']['static_friction']}" scope="parent"/>
+    <xacro:property name="wrist_3_joint_viscous_friction" value="${sec_motor_dynamics['wrist_3_joint']['viscous_friction']}" scope="parent"/>
+    <xacro:property name="wrist_3_joint_gear_ratio" value="${sec_motor_dynamics['wrist_3_joint']['gear_ratio']}" scope="parent"/>
+    <xacro:property name="wrist_3_joint_rotor_inertia" value="${sec_motor_dynamics['wrist_3_joint']['rotor_inertia']}" scope="parent"/>
+    <xacro:property name="wrist_3_joint_reducer_inertia" value="${sec_motor_dynamics['wrist_3_joint']['reducer_inertia']}" scope="parent"/>
 
     <!-- kinematics -->
     <xacro:property name="shoulder_x" value="${sec_kinematics['shoulder']['x']}" scope="parent"/>

--- a/ur_description/urdf/inc/ur_macro.xacro
+++ b/ur_description/urdf/inc/ur_macro.xacro
@@ -295,6 +295,11 @@
          <safety_controller soft_lower_limit="${shoulder_pan_lower_limit + safety_pos_margin}" soft_upper_limit="${shoulder_pan_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
+      <motor_dynamics static_friction="${shoulder_pan_joint_static_friction}"
+                      viscous_friction="${shoulder_pan_joint_viscous_friction}"
+                      gear_ratio="${shoulder_pan_joint_gear_ratio}"
+                      rotor_inertia="${shoulder_pan_joint_rotor_inertia}"
+                      reducer_inertia="${shoulder_pan_joint_reducer_inertia}"/>
     </joint>
     <joint name="${prefix}shoulder_lift_joint" type="revolute">
       <parent link="${prefix}shoulder_link" />
@@ -307,6 +312,11 @@
          <safety_controller soft_lower_limit="${shoulder_lift_lower_limit + safety_pos_margin}" soft_upper_limit="${shoulder_lift_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
+      <motor_dynamics static_friction="${shoulder_lift_joint_static_friction}"
+                      viscous_friction="${shoulder_lift_joint_viscous_friction}"
+                      gear_ratio="${shoulder_lift_joint_gear_ratio}"
+                      rotor_inertia="${shoulder_lift_joint_rotor_inertia}"
+                      reducer_inertia="${shoulder_lift_joint_reducer_inertia}"/>
     </joint>
     <joint name="${prefix}elbow_joint" type="revolute">
       <parent link="${prefix}upper_arm_link" />
@@ -319,6 +329,11 @@
          <safety_controller soft_lower_limit="${elbow_joint_lower_limit + safety_pos_margin}" soft_upper_limit="${elbow_joint_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
+      <motor_dynamics static_friction="${elbow_joint_static_friction}"
+                      viscous_friction="${elbow_joint_viscous_friction}"
+                      gear_ratio="${elbow_joint_gear_ratio}"
+                      rotor_inertia="${elbow_joint_rotor_inertia}"
+                      reducer_inertia="${elbow_joint_reducer_inertia}"/>
     </joint>
     <joint name="${prefix}wrist_1_joint" type="revolute">
       <parent link="${prefix}forearm_link" />
@@ -331,6 +346,11 @@
          <safety_controller soft_lower_limit="${wrist_1_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_1_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
+      <motor_dynamics static_friction="${wrist_1_joint_static_friction}"
+                      viscous_friction="${wrist_1_joint_viscous_friction}"
+                      gear_ratio="${wrist_1_joint_gear_ratio}"
+                      rotor_inertia="${wrist_1_joint_rotor_inertia}"
+                      reducer_inertia="${wrist_1_joint_reducer_inertia}"/>
     </joint>
     <joint name="${prefix}wrist_2_joint" type="revolute">
       <parent link="${prefix}wrist_1_link" />
@@ -343,6 +363,11 @@
          <safety_controller soft_lower_limit="${wrist_2_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_2_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
+      <motor_dynamics static_friction="${wrist_2_joint_static_friction}"
+                      viscous_friction="${wrist_2_joint_viscous_friction}"
+                      gear_ratio="${wrist_2_joint_gear_ratio}"
+                      rotor_inertia="${wrist_2_joint_rotor_inertia}"
+                      reducer_inertia="${wrist_2_joint_reducer_inertia}"/>
     </joint>
     <joint name="${prefix}wrist_3_joint" type="revolute">
       <parent link="${prefix}wrist_2_link" />
@@ -355,6 +380,11 @@
          <safety_controller soft_lower_limit="${wrist_3_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_3_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
+      <motor_dynamics static_friction="${wrist_3_joint_static_friction}"
+                      viscous_friction="${wrist_3_joint_viscous_friction}"
+                      gear_ratio="${wrist_3_joint_gear_ratio}"
+                      rotor_inertia="${wrist_3_joint_rotor_inertia}"
+                      reducer_inertia="${wrist_3_joint_reducer_inertia}"/>
     </joint>
 
     <!-- ROS-Industrial 'base' frame: base_link to UR 'Base' Coordinates transform -->

--- a/ur_description/urdf/inc/ur_macro.xacro
+++ b/ur_description/urdf/inc/ur_macro.xacro
@@ -295,11 +295,15 @@
          <safety_controller soft_lower_limit="${shoulder_pan_lower_limit + safety_pos_margin}" soft_upper_limit="${shoulder_pan_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
-      <motor_dynamics static_friction="${shoulder_pan_joint_static_friction}"
-                      viscous_friction="${shoulder_pan_joint_viscous_friction}"
-                      gear_ratio="${shoulder_pan_joint_gear_ratio}"
-                      rotor_inertia="${shoulder_pan_joint_rotor_inertia}"
-                      reducer_inertia="${shoulder_pan_joint_reducer_inertia}"/>
+      <!--
+        NB: We use `chef_dynamics` instead of `dynamics` when doing joint-torque calculations in planning;
+        `dynamics` does not have all the params we need to properly model the joint for calculating torque.
+      -->
+      <chef_dynamics coulomb_friction="${shoulder_pan_joint_coulomb_friction}"
+                     viscous_damping="${shoulder_pan_joint_viscous_damping}"
+                     gear_ratio="${shoulder_pan_joint_gear_ratio}"
+                     rotor_inertia="${shoulder_pan_joint_rotor_inertia}"
+                     reducer_inertia="${shoulder_pan_joint_reducer_inertia}"/>
     </joint>
     <joint name="${prefix}shoulder_lift_joint" type="revolute">
       <parent link="${prefix}shoulder_link" />
@@ -312,11 +316,11 @@
          <safety_controller soft_lower_limit="${shoulder_lift_lower_limit + safety_pos_margin}" soft_upper_limit="${shoulder_lift_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
-      <motor_dynamics static_friction="${shoulder_lift_joint_static_friction}"
-                      viscous_friction="${shoulder_lift_joint_viscous_friction}"
-                      gear_ratio="${shoulder_lift_joint_gear_ratio}"
-                      rotor_inertia="${shoulder_lift_joint_rotor_inertia}"
-                      reducer_inertia="${shoulder_lift_joint_reducer_inertia}"/>
+      <chef_dynamics coulomb_friction="${shoulder_lift_joint_coulomb_friction}"
+                     viscous_damping="${shoulder_lift_joint_viscous_damping}"
+                     gear_ratio="${shoulder_lift_joint_gear_ratio}"
+                     rotor_inertia="${shoulder_lift_joint_rotor_inertia}"
+                     reducer_inertia="${shoulder_lift_joint_reducer_inertia}"/>
     </joint>
     <joint name="${prefix}elbow_joint" type="revolute">
       <parent link="${prefix}upper_arm_link" />
@@ -329,11 +333,11 @@
          <safety_controller soft_lower_limit="${elbow_joint_lower_limit + safety_pos_margin}" soft_upper_limit="${elbow_joint_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
-      <motor_dynamics static_friction="${elbow_joint_static_friction}"
-                      viscous_friction="${elbow_joint_viscous_friction}"
-                      gear_ratio="${elbow_joint_gear_ratio}"
-                      rotor_inertia="${elbow_joint_rotor_inertia}"
-                      reducer_inertia="${elbow_joint_reducer_inertia}"/>
+      <chef_dynamics coulomb_friction="${elbow_joint_coulomb_friction}"
+                     viscous_damping="${elbow_joint_viscous_damping}"
+                     gear_ratio="${elbow_joint_gear_ratio}"
+                     rotor_inertia="${elbow_joint_rotor_inertia}"
+                     reducer_inertia="${elbow_joint_reducer_inertia}"/>
     </joint>
     <joint name="${prefix}wrist_1_joint" type="revolute">
       <parent link="${prefix}forearm_link" />
@@ -346,11 +350,11 @@
          <safety_controller soft_lower_limit="${wrist_1_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_1_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
-      <motor_dynamics static_friction="${wrist_1_joint_static_friction}"
-                      viscous_friction="${wrist_1_joint_viscous_friction}"
-                      gear_ratio="${wrist_1_joint_gear_ratio}"
-                      rotor_inertia="${wrist_1_joint_rotor_inertia}"
-                      reducer_inertia="${wrist_1_joint_reducer_inertia}"/>
+      <chef_dynamics coulomb_friction="${wrist_1_joint_coulomb_friction}"
+                     viscous_damping="${wrist_1_joint_viscous_damping}"
+                     gear_ratio="${wrist_1_joint_gear_ratio}"
+                     rotor_inertia="${wrist_1_joint_rotor_inertia}"
+                     reducer_inertia="${wrist_1_joint_reducer_inertia}"/>
     </joint>
     <joint name="${prefix}wrist_2_joint" type="revolute">
       <parent link="${prefix}wrist_1_link" />
@@ -363,11 +367,11 @@
          <safety_controller soft_lower_limit="${wrist_2_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_2_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
-      <motor_dynamics static_friction="${wrist_2_joint_static_friction}"
-                      viscous_friction="${wrist_2_joint_viscous_friction}"
-                      gear_ratio="${wrist_2_joint_gear_ratio}"
-                      rotor_inertia="${wrist_2_joint_rotor_inertia}"
-                      reducer_inertia="${wrist_2_joint_reducer_inertia}"/>
+      <chef_dynamics coulomb_friction="${wrist_2_joint_coulomb_friction}"
+                     viscous_damping="${wrist_2_joint_viscous_damping}"
+                     gear_ratio="${wrist_2_joint_gear_ratio}"
+                     rotor_inertia="${wrist_2_joint_rotor_inertia}"
+                     reducer_inertia="${wrist_2_joint_reducer_inertia}"/>
     </joint>
     <joint name="${prefix}wrist_3_joint" type="revolute">
       <parent link="${prefix}wrist_2_link" />
@@ -380,11 +384,11 @@
          <safety_controller soft_lower_limit="${wrist_3_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_3_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
-      <motor_dynamics static_friction="${wrist_3_joint_static_friction}"
-                      viscous_friction="${wrist_3_joint_viscous_friction}"
-                      gear_ratio="${wrist_3_joint_gear_ratio}"
-                      rotor_inertia="${wrist_3_joint_rotor_inertia}"
-                      reducer_inertia="${wrist_3_joint_reducer_inertia}"/>
+      <chef_dynamics coulomb_friction="${wrist_3_joint_coulomb_friction}"
+                     viscous_damping="${wrist_3_joint_viscous_damping}"
+                     gear_ratio="${wrist_3_joint_gear_ratio}"
+                     rotor_inertia="${wrist_3_joint_rotor_inertia}"
+                     reducer_inertia="${wrist_3_joint_reducer_inertia}"/>
     </joint>
 
     <!-- ROS-Industrial 'base' frame: base_link to UR 'Base' Coordinates transform -->


### PR DESCRIPTION
Populate `joint` blocks with `chef_dynamics` blocks. Support `chef_dynamics` params are:
- `coulomb_friction`, `viscous_damping`, `gear_ratio`, `rotor_inertia`, `reducer_inertia`

NB: These are separate from the existing `dynamics` params, since those may have meaning to some existing consumers of the URDF, and their values maybe not be exactly the same as `coulomb_friction` and `viscous_damping`; extending `dynamics` was considered, but decided against for a couple reasons: 1) Can use the exact param names we want, 2) Not guaranteed all URDF processors handle unexpected param names, 3) Not modifying params that existing tools (like Gazebo) might already be using. Not very strong reasons, so we could certainly switch to extending `dynamics`, as opposed to adding a new `chef_dynamics` tag as done in this PR.

### Testing
- [x] `universal_robot` builds locally
- [x] Inspect `robot_description` after launching a UR5e and confirm `motor_dynamics` was populated for every joint correctly. 