### PR TITLE
:weight_lifting: :recycle: Make joint dynamics optional

### DIFF
--- a/ur_description/urdf/inc/ur_common.xacro
+++ b/ur_description/urdf/inc/ur_common.xacro
@@ -38,7 +38,6 @@
     <xacro:property name="sec_limits" value="${config_joint_limit_parameters['joint_limits']}"/>
     <xacro:property name="sec_offsets" value="${config_physical_parameters['offsets']}"/>
     <xacro:property name="sec_inertia_parameters" value="${config_physical_parameters['inertia_parameters']}" />
-    <xacro:property name="sec_joint_dynamics" value="${config_physical_parameters['joint_dynamics']}" />
     <xacro:property name="sec_mesh_files" value="${config_visual_parameters['mesh_files']}" />
     <xacro:property name="sec_kinematics" value="${config_kinematics_parameters['kinematics']}" />
 
@@ -69,41 +68,91 @@
     <xacro:property name="wrist_3_effort_limit" value="${sec_limits['wrist_3_joint']['max_effort']}" scope="parent"/>
 
     <!-- JOINT DYNAMICS PARAMETERS -->
-    <xacro:property name="shoulder_pan_joint_coulomb_friction" value="${sec_joint_dynamics['shoulder_pan_joint']['coulomb_friction']}" scope="parent"/>
-    <xacro:property name="shoulder_pan_joint_viscous_damping" value="${sec_joint_dynamics['shoulder_pan_joint']['viscous_damping']}" scope="parent"/>
-    <xacro:property name="shoulder_pan_joint_gear_ratio" value="${sec_joint_dynamics['shoulder_pan_joint']['gear_ratio']}" scope="parent"/>
-    <xacro:property name="shoulder_pan_joint_rotor_inertia" value="${sec_joint_dynamics['shoulder_pan_joint']['rotor_inertia']}" scope="parent"/>
-    <xacro:property name="shoulder_pan_joint_reducer_inertia" value="${sec_joint_dynamics['shoulder_pan_joint']['reducer_inertia']}" scope="parent"/>
+    <xacro:if value="${'joint_dynamics' in config_physical_parameters}">
+      <xacro:property name="sec_joint_dynamics" value="${config_physical_parameters['joint_dynamics']}" />
 
-    <xacro:property name="shoulder_lift_joint_coulomb_friction" value="${sec_joint_dynamics['shoulder_lift_joint']['coulomb_friction']}" scope="parent"/>
-    <xacro:property name="shoulder_lift_joint_viscous_damping" value="${sec_joint_dynamics['shoulder_lift_joint']['viscous_damping']}" scope="parent"/>
-    <xacro:property name="shoulder_lift_joint_gear_ratio" value="${sec_joint_dynamics['shoulder_lift_joint']['gear_ratio']}" scope="parent"/>
-    <xacro:property name="shoulder_lift_joint_rotor_inertia" value="${sec_joint_dynamics['shoulder_lift_joint']['rotor_inertia']}" scope="parent"/>
-    <xacro:property name="shoulder_lift_joint_reducer_inertia" value="${sec_joint_dynamics['shoulder_lift_joint']['reducer_inertia']}" scope="parent"/>
+      <xacro:if value="${'shoulder_pan_joint' in sec_joint_dynamics}">
+        <xacro:property name="has_shoulder_pan_joint_dynamics" value="true" scope="parent"/>
+        <xacro:property name="shoulder_pan_joint_coulomb_friction" value="${sec_joint_dynamics['shoulder_pan_joint']['coulomb_friction'] if 'coulomb_friction' in sec_joint_dynamics['shoulder_pan_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="shoulder_pan_joint_viscous_damping" value="${sec_joint_dynamics['shoulder_pan_joint']['viscous_damping'] if 'viscous_damping' in sec_joint_dynamics['shoulder_pan_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="shoulder_pan_joint_gear_ratio" value="${sec_joint_dynamics['shoulder_pan_joint']['gear_ratio'] if 'gear_ratio' in sec_joint_dynamics['shoulder_pan_joint'] else 1.0}" scope="parent"/>
+        <xacro:property name="shoulder_pan_joint_rotor_inertia" value="${sec_joint_dynamics['shoulder_pan_joint']['rotor_inertia'] if 'rotor_inertia' in sec_joint_dynamics['shoulder_pan_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="shoulder_pan_joint_reducer_inertia" value="${sec_joint_dynamics['shoulder_pan_joint']['reducer_inertia'] if 'reducer_inertia' in sec_joint_dynamics['shoulder_pan_joint'] else 0.0}" scope="parent"/>
+      </xacro:if>
+      <xacro:unless value="${'shoulder_pan_joint' in sec_joint_dynamics}">
+        <xacro:property name="has_shoulder_pan_joint_dynamics" value="false" scope="parent"/>
+      </xacro:unless>
 
-    <xacro:property name="elbow_joint_coulomb_friction" value="${sec_joint_dynamics['elbow_joint']['coulomb_friction']}" scope="parent"/>
-    <xacro:property name="elbow_joint_viscous_damping" value="${sec_joint_dynamics['elbow_joint']['viscous_damping']}" scope="parent"/>
-    <xacro:property name="elbow_joint_gear_ratio" value="${sec_joint_dynamics['elbow_joint']['gear_ratio']}" scope="parent"/>
-    <xacro:property name="elbow_joint_rotor_inertia" value="${sec_joint_dynamics['elbow_joint']['rotor_inertia']}" scope="parent"/>
-    <xacro:property name="elbow_joint_reducer_inertia" value="${sec_joint_dynamics['elbow_joint']['reducer_inertia']}" scope="parent"/>
+      <xacro:if value="${'shoulder_lift_joint' in sec_joint_dynamics}">
+        <xacro:property name="has_shoulder_lift_joint_dynamics" value="true" scope="parent"/>
+        <xacro:property name="shoulder_lift_joint_coulomb_friction" value="${sec_joint_dynamics['shoulder_lift_joint']['coulomb_friction'] if 'coulomb_friction' in sec_joint_dynamics['shoulder_lift_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="shoulder_lift_joint_viscous_damping" value="${sec_joint_dynamics['shoulder_lift_joint']['viscous_damping'] if 'viscous_damping' in sec_joint_dynamics['shoulder_lift_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="shoulder_lift_joint_gear_ratio" value="${sec_joint_dynamics['shoulder_lift_joint']['gear_ratio'] if 'gear_ratio' in sec_joint_dynamics['shoulder_lift_joint'] else 1.0}" scope="parent"/>
+        <xacro:property name="shoulder_lift_joint_rotor_inertia" value="${sec_joint_dynamics['shoulder_lift_joint']['rotor_inertia'] if 'rotor_inertia' in sec_joint_dynamics['shoulder_lift_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="shoulder_lift_joint_reducer_inertia" value="${sec_joint_dynamics['shoulder_lift_joint']['reducer_inertia'] if 'reducer_inertia' in sec_joint_dynamics['shoulder_lift_joint'] else 0.0}" scope="parent"/>
+      </xacro:if>
+      <xacro:unless value="${'shoulder_lift_joint' in sec_joint_dynamics}">
+        <xacro:property name="has_shoulder_lift_joint_dynamics" value="false" scope="parent"/>
+      </xacro:unless>
 
-    <xacro:property name="wrist_1_joint_coulomb_friction" value="${sec_joint_dynamics['wrist_1_joint']['coulomb_friction']}" scope="parent"/>
-    <xacro:property name="wrist_1_joint_viscous_damping" value="${sec_joint_dynamics['wrist_1_joint']['viscous_damping']}" scope="parent"/>
-    <xacro:property name="wrist_1_joint_gear_ratio" value="${sec_joint_dynamics['wrist_1_joint']['gear_ratio']}" scope="parent"/>
-    <xacro:property name="wrist_1_joint_rotor_inertia" value="${sec_joint_dynamics['wrist_1_joint']['rotor_inertia']}" scope="parent"/>
-    <xacro:property name="wrist_1_joint_reducer_inertia" value="${sec_joint_dynamics['wrist_1_joint']['reducer_inertia']}" scope="parent"/>
+      <xacro:if value="${'elbow_joint' in sec_joint_dynamics}">
+        <xacro:property name="has_elbow_joint_dynamics" value="true" scope="parent"/>
+        <xacro:property name="elbow_joint_coulomb_friction" value="${sec_joint_dynamics['elbow_joint']['coulomb_friction'] if 'coulomb_friction' in sec_joint_dynamics['elbow_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="elbow_joint_viscous_damping" value="${sec_joint_dynamics['elbow_joint']['viscous_damping'] if 'viscous_damping' in sec_joint_dynamics['elbow_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="elbow_joint_gear_ratio" value="${sec_joint_dynamics['elbow_joint']['gear_ratio'] if 'gear_ratio' in sec_joint_dynamics['elbow_joint'] else 1.0}" scope="parent"/>
+        <xacro:property name="elbow_joint_rotor_inertia" value="${sec_joint_dynamics['elbow_joint']['rotor_inertia'] if 'rotor_inertia' in sec_joint_dynamics['elbow_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="elbow_joint_reducer_inertia" value="${sec_joint_dynamics['elbow_joint']['reducer_inertia'] if 'reducer_inertia' in sec_joint_dynamics['elbow_joint'] else 0.0}" scope="parent"/>
+      </xacro:if>
+      <xacro:unless value="${'elbow_joint' in sec_joint_dynamics}">
+        <xacro:property name="has_elbow_joint_dynamics" value="false" scope="parent"/>
+      </xacro:unless>
 
-    <xacro:property name="wrist_2_joint_coulomb_friction" value="${sec_joint_dynamics['wrist_2_joint']['coulomb_friction']}" scope="parent"/>
-    <xacro:property name="wrist_2_joint_viscous_damping" value="${sec_joint_dynamics['wrist_2_joint']['viscous_damping']}" scope="parent"/>
-    <xacro:property name="wrist_2_joint_gear_ratio" value="${sec_joint_dynamics['wrist_2_joint']['gear_ratio']}" scope="parent"/>
-    <xacro:property name="wrist_2_joint_rotor_inertia" value="${sec_joint_dynamics['wrist_2_joint']['rotor_inertia']}" scope="parent"/>
-    <xacro:property name="wrist_2_joint_reducer_inertia" value="${sec_joint_dynamics['wrist_2_joint']['reducer_inertia']}" scope="parent"/>
+      <xacro:if value="${'wrist_1_joint' in sec_joint_dynamics}">
+        <xacro:property name="has_wrist_1_joint_dynamics" value="true" scope="parent"/>
+        <xacro:property name="wrist_1_joint_coulomb_friction" value="${sec_joint_dynamics['wrist_1_joint']['coulomb_friction'] if 'coulomb_friction' in sec_joint_dynamics['wrist_1_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="wrist_1_joint_viscous_damping" value="${sec_joint_dynamics['wrist_1_joint']['viscous_damping'] if 'viscous_damping' in sec_joint_dynamics['wrist_1_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="wrist_1_joint_gear_ratio" value="${sec_joint_dynamics['wrist_1_joint']['gear_ratio'] if 'gear_ratio' in sec_joint_dynamics['wrist_1_joint'] else 1.0}" scope="parent"/>
+        <xacro:property name="wrist_1_joint_rotor_inertia" value="${sec_joint_dynamics['wrist_1_joint']['rotor_inertia'] if 'rotor_inertia' in sec_joint_dynamics['wrist_1_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="wrist_1_joint_reducer_inertia" value="${sec_joint_dynamics['wrist_1_joint']['reducer_inertia'] if 'reducer_inertia' in sec_joint_dynamics['wrist_1_joint'] else 0.0}" scope="parent"/>
+      </xacro:if>
+      <xacro:unless value="${'wrist_1_joint' in sec_joint_dynamics}">
+        <xacro:property name="has_wrist_1_joint_dynamics" value="false" scope="parent"/>
+      </xacro:unless>
 
-    <xacro:property name="wrist_3_joint_coulomb_friction" value="${sec_joint_dynamics['wrist_3_joint']['coulomb_friction']}" scope="parent"/>
-    <xacro:property name="wrist_3_joint_viscous_damping" value="${sec_joint_dynamics['wrist_3_joint']['viscous_damping']}" scope="parent"/>
-    <xacro:property name="wrist_3_joint_gear_ratio" value="${sec_joint_dynamics['wrist_3_joint']['gear_ratio']}" scope="parent"/>
-    <xacro:property name="wrist_3_joint_rotor_inertia" value="${sec_joint_dynamics['wrist_3_joint']['rotor_inertia']}" scope="parent"/>
-    <xacro:property name="wrist_3_joint_reducer_inertia" value="${sec_joint_dynamics['wrist_3_joint']['reducer_inertia']}" scope="parent"/>
+      <xacro:if value="${'wrist_2_joint' in sec_joint_dynamics}">
+        <xacro:property name="has_wrist_2_joint_dynamics" value="true" scope="parent"/>
+        <xacro:property name="wrist_2_joint_coulomb_friction" value="${sec_joint_dynamics['wrist_2_joint']['coulomb_friction'] if 'coulomb_friction' in sec_joint_dynamics['wrist_2_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="wrist_2_joint_viscous_damping" value="${sec_joint_dynamics['wrist_2_joint']['viscous_damping'] if 'viscous_damping' in sec_joint_dynamics['wrist_2_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="wrist_2_joint_gear_ratio" value="${sec_joint_dynamics['wrist_2_joint']['gear_ratio'] if 'gear_ratio' in sec_joint_dynamics['wrist_2_joint'] else 1.0}" scope="parent"/>
+        <xacro:property name="wrist_2_joint_rotor_inertia" value="${sec_joint_dynamics['wrist_2_joint']['rotor_inertia'] if 'rotor_inertia' in sec_joint_dynamics['wrist_2_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="wrist_2_joint_reducer_inertia" value="${sec_joint_dynamics['wrist_2_joint']['reducer_inertia'] if 'reducer_inertia' in sec_joint_dynamics['wrist_2_joint'] else 0.0}" scope="parent"/>
+      </xacro:if>
+      <xacro:unless value="${'wrist_2_joint' in sec_joint_dynamics}">
+        <xacro:property name="has_wrist_2_joint_dynamics" value="false" scope="parent"/>
+      </xacro:unless>
+
+      <xacro:if value="${'wrist_3_joint' in sec_joint_dynamics}">
+        <xacro:property name="has_wrist_3_joint_dynamics" value="true" scope="parent"/>
+        <xacro:property name="wrist_3_joint_coulomb_friction" value="${sec_joint_dynamics['wrist_3_joint']['coulomb_friction'] if 'coulomb_friction' in sec_joint_dynamics['wrist_3_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="wrist_3_joint_viscous_damping" value="${sec_joint_dynamics['wrist_3_joint']['viscous_damping'] if 'viscous_damping' in sec_joint_dynamics['wrist_3_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="wrist_3_joint_gear_ratio" value="${sec_joint_dynamics['wrist_3_joint']['gear_ratio'] if 'gear_ratio' in sec_joint_dynamics['wrist_3_joint'] else 1.0}" scope="parent"/>
+        <xacro:property name="wrist_3_joint_rotor_inertia" value="${sec_joint_dynamics['wrist_3_joint']['rotor_inertia'] if 'rotor_inertia' in sec_joint_dynamics['wrist_3_joint'] else 0.0}" scope="parent"/>
+        <xacro:property name="wrist_3_joint_reducer_inertia" value="${sec_joint_dynamics['wrist_3_joint']['reducer_inertia'] if 'reducer_inertia' in sec_joint_dynamics['wrist_3_joint'] else 0.0}" scope="parent"/>
+      </xacro:if>
+      <xacro:unless value="${'wrist_3_joint' in sec_joint_dynamics}">
+        <xacro:property name="has_wrist_3_joint_dynamics" value="false" scope="parent"/>
+      </xacro:unless>
+    </xacro:if>
+
+    <!-- If joint_dynamics section doesn't exist at all, set all flags to false -->
+    <xacro:unless value="${'joint_dynamics' in config_physical_parameters}">
+      <xacro:property name="has_shoulder_pan_joint_dynamics" value="false" scope="parent"/>
+      <xacro:property name="has_shoulder_lift_joint_dynamics" value="false" scope="parent"/>
+      <xacro:property name="has_elbow_joint_dynamics" value="false" scope="parent"/>
+      <xacro:property name="has_wrist_1_joint_dynamics" value="false" scope="parent"/>
+      <xacro:property name="has_wrist_2_joint_dynamics" value="false" scope="parent"/>
+      <xacro:property name="has_wrist_3_joint_dynamics" value="false" scope="parent"/>
+    </xacro:unless>
 
     <!-- kinematics -->
     <xacro:property name="shoulder_x" value="${sec_kinematics['shoulder']['x']}" scope="parent"/>

--- a/ur_description/urdf/inc/ur_macro.xacro
+++ b/ur_description/urdf/inc/ur_macro.xacro
@@ -299,11 +299,13 @@
         NB: We use `chef_dynamics` instead of `dynamics` when doing joint-torque calculations in planning;
         `dynamics` does not have all the params we need to properly model the joint for calculating torque.
       -->
-      <chef_dynamics coulomb_friction="${shoulder_pan_joint_coulomb_friction}"
-                     viscous_damping="${shoulder_pan_joint_viscous_damping}"
-                     gear_ratio="${shoulder_pan_joint_gear_ratio}"
-                     rotor_inertia="${shoulder_pan_joint_rotor_inertia}"
-                     reducer_inertia="${shoulder_pan_joint_reducer_inertia}"/>
+      <xacro:if value="${has_shoulder_pan_joint_dynamics}">
+        <chef_dynamics coulomb_friction="${shoulder_pan_joint_coulomb_friction}"
+                       viscous_damping="${shoulder_pan_joint_viscous_damping}"
+                       gear_ratio="${shoulder_pan_joint_gear_ratio}"
+                       rotor_inertia="${shoulder_pan_joint_rotor_inertia}"
+                       reducer_inertia="${shoulder_pan_joint_reducer_inertia}"/>
+      </xacro:if>
     </joint>
     <joint name="${prefix}shoulder_lift_joint" type="revolute">
       <parent link="${prefix}shoulder_link" />
@@ -316,11 +318,13 @@
          <safety_controller soft_lower_limit="${shoulder_lift_lower_limit + safety_pos_margin}" soft_upper_limit="${shoulder_lift_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
-      <chef_dynamics coulomb_friction="${shoulder_lift_joint_coulomb_friction}"
-                     viscous_damping="${shoulder_lift_joint_viscous_damping}"
-                     gear_ratio="${shoulder_lift_joint_gear_ratio}"
-                     rotor_inertia="${shoulder_lift_joint_rotor_inertia}"
-                     reducer_inertia="${shoulder_lift_joint_reducer_inertia}"/>
+      <xacro:if value="${has_shoulder_lift_joint_dynamics}">
+        <chef_dynamics coulomb_friction="${shoulder_lift_joint_coulomb_friction}"
+                       viscous_damping="${shoulder_lift_joint_viscous_damping}"
+                       gear_ratio="${shoulder_lift_joint_gear_ratio}"
+                       rotor_inertia="${shoulder_lift_joint_rotor_inertia}"
+                       reducer_inertia="${shoulder_lift_joint_reducer_inertia}"/>
+      </xacro:if>
     </joint>
     <joint name="${prefix}elbow_joint" type="revolute">
       <parent link="${prefix}upper_arm_link" />
@@ -333,11 +337,13 @@
          <safety_controller soft_lower_limit="${elbow_joint_lower_limit + safety_pos_margin}" soft_upper_limit="${elbow_joint_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
-      <chef_dynamics coulomb_friction="${elbow_joint_coulomb_friction}"
-                     viscous_damping="${elbow_joint_viscous_damping}"
-                     gear_ratio="${elbow_joint_gear_ratio}"
-                     rotor_inertia="${elbow_joint_rotor_inertia}"
-                     reducer_inertia="${elbow_joint_reducer_inertia}"/>
+      <xacro:if value="${has_elbow_joint_dynamics}">
+        <chef_dynamics coulomb_friction="${elbow_joint_coulomb_friction}"
+                       viscous_damping="${elbow_joint_viscous_damping}"
+                       gear_ratio="${elbow_joint_gear_ratio}"
+                       rotor_inertia="${elbow_joint_rotor_inertia}"
+                       reducer_inertia="${elbow_joint_reducer_inertia}"/>
+      </xacro:if>
     </joint>
     <joint name="${prefix}wrist_1_joint" type="revolute">
       <parent link="${prefix}forearm_link" />
@@ -350,11 +356,13 @@
          <safety_controller soft_lower_limit="${wrist_1_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_1_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
-      <chef_dynamics coulomb_friction="${wrist_1_joint_coulomb_friction}"
-                     viscous_damping="${wrist_1_joint_viscous_damping}"
-                     gear_ratio="${wrist_1_joint_gear_ratio}"
-                     rotor_inertia="${wrist_1_joint_rotor_inertia}"
-                     reducer_inertia="${wrist_1_joint_reducer_inertia}"/>
+      <xacro:if value="${has_wrist_1_joint_dynamics}">
+        <chef_dynamics coulomb_friction="${wrist_1_joint_coulomb_friction}"
+                       viscous_damping="${wrist_1_joint_viscous_damping}"
+                       gear_ratio="${wrist_1_joint_gear_ratio}"
+                       rotor_inertia="${wrist_1_joint_rotor_inertia}"
+                       reducer_inertia="${wrist_1_joint_reducer_inertia}"/>
+      </xacro:if>
     </joint>
     <joint name="${prefix}wrist_2_joint" type="revolute">
       <parent link="${prefix}wrist_1_link" />
@@ -367,11 +375,13 @@
          <safety_controller soft_lower_limit="${wrist_2_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_2_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
-      <chef_dynamics coulomb_friction="${wrist_2_joint_coulomb_friction}"
-                     viscous_damping="${wrist_2_joint_viscous_damping}"
-                     gear_ratio="${wrist_2_joint_gear_ratio}"
-                     rotor_inertia="${wrist_2_joint_rotor_inertia}"
-                     reducer_inertia="${wrist_2_joint_reducer_inertia}"/>
+      <xacro:if value="${has_wrist_2_joint_dynamics}">
+        <chef_dynamics coulomb_friction="${wrist_2_joint_coulomb_friction}"
+                       viscous_damping="${wrist_2_joint_viscous_damping}"
+                       gear_ratio="${wrist_2_joint_gear_ratio}"
+                       rotor_inertia="${wrist_2_joint_rotor_inertia}"
+                       reducer_inertia="${wrist_2_joint_reducer_inertia}"/>
+      </xacro:if>
     </joint>
     <joint name="${prefix}wrist_3_joint" type="revolute">
       <parent link="${prefix}wrist_2_link" />
@@ -384,11 +394,13 @@
          <safety_controller soft_lower_limit="${wrist_3_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_3_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
-      <chef_dynamics coulomb_friction="${wrist_3_joint_coulomb_friction}"
-                     viscous_damping="${wrist_3_joint_viscous_damping}"
-                     gear_ratio="${wrist_3_joint_gear_ratio}"
-                     rotor_inertia="${wrist_3_joint_rotor_inertia}"
-                     reducer_inertia="${wrist_3_joint_reducer_inertia}"/>
+      <xacro:if value="${has_wrist_3_joint_dynamics}">
+        <chef_dynamics coulomb_friction="${wrist_3_joint_coulomb_friction}"
+                       viscous_damping="${wrist_3_joint_viscous_damping}"
+                       gear_ratio="${wrist_3_joint_gear_ratio}"
+                       rotor_inertia="${wrist_3_joint_rotor_inertia}"
+                       reducer_inertia="${wrist_3_joint_reducer_inertia}"/>
+      </xacro:if>
     </joint>
 
     <!-- ROS-Industrial 'base' frame: base_link to UR 'Base' Coordinates transform -->


### PR DESCRIPTION
#1 Added support for a new `chef_dynamics` element inside a `joint`; these were populated from the arm's physical properties file `joint_dynamics` block. The top-level `ur_robot` macro fails if `joint_dynamics` isn't specified; this PR updates `ur_robot` so that `joint_dynamics` is now optional, per-joint.

### Testing
- [x] `ur_description` builds successfully
- [x] Loading a ur5 -- which doesn't have `joint_dynamics` defined -- works